### PR TITLE
Allow except in forwarder plugin

### DIFF
--- a/charts/node-local-dns/templates/configmap.yaml
+++ b/charts/node-local-dns/templates/configmap.yaml
@@ -61,6 +61,9 @@ data:
       {{- if $zone.plugins.forward.health_check }}
         expire {{ $zone.plugins.forward.health_check }}
       {{- end }}
+      {{- if $zone.plugins.forward.except }}
+        except {{ $zone.plugins.forward.except }}
+      {{- end }}
       }
       {{- if $zone.plugins.prometheus }}
       prometheus :{{ $metricsPort }}

--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -47,6 +47,7 @@ config:
           max_fails: "" # 10
           expire: "" # 10s
           health_check: "" # 10s
+          except: "" # space-separated list of domains to exclude from forwarding
         prometheus: true
         health:
           port: 8080


### PR DESCRIPTION
Sometimes you want to configure your forwarder to exclude some Domains. As explained in https://coredns.io/plugins/forward/ this can be done by using the "except" stanza