### PR TITLE
Fix Container Image Registry from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  repository: k8s.gcr.io/dns/k8s-dns-node-cache
+  repository: registry.k8s.io/dns/k8s-dns-node-cache
   pullPolicy: IfNotPresent
   tag: 1.17.4
   args:


### PR DESCRIPTION
This PR just changes the domain name from where the images will be pulled off to the new one provided by the k8s community as documented in https://kubernetes.io/blog/2023/03/10/image-registry-redirect/