### PR TITLE
Add possibility to use cilium LocalRedirectPolicy CRD

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -11,19 +11,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run chart-testing (lint)
-        id: lint
-        uses: helm/chart-testing-action@v2.4.0
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
         with:
-          command: lint
-          config: ct.yaml
+          version: v3.12.1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.8.0
-        if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v2.4.0
-        with:
-          command: install
-          config: ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/charts/node-local-dns/Chart.yaml
+++ b/charts/node-local-dns/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: node-local-dns
-version: 1.4.0-rc.1
-appVersion: 1.22.9
+version: 1.4.0-rc.2
+appVersion: 1.22.24
 home: https://github.com/lablabs/k8s-nodelocaldns-helm
 description: NodeLocal DNS Cache helm chart
 keywords:

--- a/charts/node-local-dns/README.md
+++ b/charts/node-local-dns/README.md
@@ -7,6 +7,12 @@ helm repo add k8s-nodelocaldns-helm  https://lablabs.github.io/k8s-nodelocaldns-
 helm install k8s-nodelocaldns-helm/node-local-dns
 ```
 
+### Testing
+
+```console
+helm test node-local-dns
+```
+
 ## Configuration
 
 This chart deploys NodeLocal DNSCache Daemon set according to <https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/>.

--- a/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
+++ b/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
@@ -1,0 +1,33 @@
+{{- if hasKey .Values.config "cilium" }}
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "node-local-dns"
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: {{ .Values.config.cilium.clusterDNSService | default "kube-dns" }}
+      namespace: {{ .Values.config.cilium.clusterDNSNamespace | default "kube-system" }}
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        {{- include "node-local-dns.selectorLabels" . | nindent 8 }}
+    toPorts:
+      {{- if .Values.config.cilium.udp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+        protocol: UDP
+     {{- end }}
+     {{- if .Values.config.cilium.tcp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+        protocol: TCP
+     {{- end }}
+{{- end }}

--- a/charts/node-local-dns/templates/configmap.yaml
+++ b/charts/node-local-dns/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
   Corefile: |-
     {{- $localDnsIp := .Values.config.localDnsIp -}}
     {{- $metricsPort := .Values.metrics.port -}}
+    {{- $ciliumConfig := ternary true false (hasKey .Values.config "cilium") -}}
 
     {{- range $k, $v := .Values.config.zones }}
     {{ $k }} {
@@ -42,7 +43,11 @@ data:
       debug
       {{- end }}
       loop
+      {{- if not $ciliumConfig }}
       bind {{ $localDnsIp }}
+      {{- else }}
+      bind 0.0.0.0
+      {{- end }}
       forward . {{ $v.plugins.forward.parameters }} {
       {{- if $v.plugins.forward.policy }}
         policy {{ $v.plugins.forward.policy }}
@@ -70,7 +75,11 @@ data:
       prometheus :{{ $metricsPort }}
       {{- end }}
       {{- if $v.plugins.health }}
+      {{- if not $ciliumConfig }}
       health {{ $localDnsIp }}:{{ $v.plugins.health.port }}
+      {{- else }}
+      health
+      {{- end }}
       {{- end }}
     {{- end }}
     }

--- a/charts/node-local-dns/templates/daemonset.yaml
+++ b/charts/node-local-dns/templates/daemonset.yaml
@@ -29,7 +29,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       priorityClassName: {{ .Values.priorityClassName }}
+      {{- if not (hasKey .Values.config "cilium") }}
       hostNetwork: {{ .Values.useHostNetwork }}
+      {{- end }}
       dnsPolicy: Default
       containers:
         - name: {{ .Chart.Name }}
@@ -39,16 +41,22 @@ spec:
             - -localip
             - "{{ .Values.config.localDnsIp }}"
             {{- if .Values.image.args.skipTeardown }}
-            - -skipteardown
+            - -skipteardown=true
+            {{- else }}
+            - -skipteardown=false
             {{- end }}
             {{- if .Values.image.args.setupEptables }}
             - -setupeptables
             {{- end }}
             {{- if .Values.image.args.setupInterface }}
-            - -setupinterface
+            - -setupinterface=true
+            {{- else }}
+            - -setupinterface=false
             {{- end }}
             {{- if .Values.image.args.setupIptables }}
-            - -setupiptables
+            - -setupiptables=true
+            {{- else }}
+            - -setupiptables=false
             {{- end }}
             {{- if .Values.image.args.quiet }}
             - -quiet
@@ -65,19 +73,35 @@ spec:
             - /etc/Corefile
             - -syncinterval
             - {{ .Values.image.args.syncInterval }}
+            {{- if .Values.image.args.setupInterface }}
             - -interfacename
             - {{ .Values.image.args.interfaceName }}
+            {{- end }}
             - -metrics-listen-address
             - "0.0.0.0:{{ add .Values.metrics.port 100 }}"
           ports:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
+          {{- if (hasKey .Values.config "cilium") }}
+          {{- if .Values.config.cilium.udp.enabled }}
+            - name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+              containerPort: 53
+              protocol: UDP
+          {{- end }}
+          {{- if .Values.config.cilium.tcp.enabled }}
+            - name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+              containerPort: 53
+              protocol: TCP
+          {{- end }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           livenessProbe:
             httpGet:
+              {{- if not (hasKey .Values.config "cilium") }}
               host: {{ .Values.config.localDnsIp }}
+              {{- end }}
               path: /health
               port: {{ default "8080" .Values.image.args.healthPort }}
             initialDelaySeconds: 60

--- a/charts/node-local-dns/templates/service.yaml
+++ b/charts/node-local-dns/templates/service.yaml
@@ -1,0 +1,31 @@
+{{- if hasKey .Values.config "cilium" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.image.args.upstreamSvc }}
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+    k8s-app: kube-dns
+    kubernetes.io/name: "KubeDNSUpstream"
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+  {{- if .Values.config.cilium.udp.enabled }}
+  - name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  {{- end }}
+  {{- if .Values.config.cilium.tcp.enabled }}
+  - name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  {{- end }}
+  selector:
+    k8s-app: kube-dns
+{{- end }}

--- a/charts/node-local-dns/templates/serviceaccount.yaml
+++ b/charts/node-local-dns/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.serviceAccount.create }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/node-local-dns/templates/tests/test-dns-resolution.yaml
+++ b/charts/node-local-dns/templates/tests/test-dns-resolution.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "node-local-dns.fullname" . }}-dns-test"
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: dns-test
+      image: tutum/dnsutils
+      command: ['dig']
+      args: ['google.com']
+  restartPolicy: Never

--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -2,21 +2,30 @@
 image:
   repository: registry.k8s.io/dns/k8s-dns-node-cache
   pullPolicy: IfNotPresent
-  tag: 1.22.9
+  tag: 1.22.24
   args:
     interfaceName: nodelocaldns
     healthPort: 8080
     skipTeardown: true
     syncInterval: 1ns
-#    setupIptables: false
-#    setupEbtables: false
-#    quiet: false
-#    upstreamSvc: kube-dns
+    setupIptables: true
+    setupEbtables: true
+    quiet: false
+    upstreamSvc: kube-dns
 
 imagePullSecrets: []
 
 config:
   localDnsIp: 169.254.20.11
+#  cilium:
+#    clusterDNSService: kube-dns
+#    clusterDNSNamespace: kube-system
+#    udp:
+#      enabled: true
+#      portName: dns
+#    tcp:
+#      enabled: true
+#      portName: dns-tcp
   zones:
     .:53:
       plugins:
@@ -84,6 +93,7 @@ config:
         health:
           port: 8080
 
+# useHostNetwork is always false when using cilium
 useHostNetwork: true
 
 updateStrategy:


### PR DESCRIPTION
Hi @MonolithProjects,

This PR makes the usage of Cilium [local-redirect-policy](https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/) CRD possible without changing the original usage of the project.

Additionally, the following changes were done,

* Fix and update CI lint, based on [chart-testing-action](https://github.com/helm/chart-testing-action) recommendation.
* Update node-local-dns image to the latest available upstream
* Add trivial `helm test` resolving `google.com`, which also runs on CI Lint GH Action run.

Thank you!