### PR TITLE
Add support for dns.hosts plugin

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,11 +18,11 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/charts/node-local-dns/Chart.yaml
+++ b/charts/node-local-dns/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: node-local-dns
-version: 1.4.0-rc.2
+version: 1.4.0-rc.3
 appVersion: 1.22.24
 home: https://github.com/lablabs/k8s-nodelocaldns-helm
 description: NodeLocal DNS Cache helm chart

--- a/charts/node-local-dns/templates/configmap.yaml
+++ b/charts/node-local-dns/templates/configmap.yaml
@@ -34,6 +34,25 @@ data:
       {{- if $v.plugins.reload }}
       reload
       {{- end }}
+      {{- if $v.plugins.hosts }}
+      hosts {
+      {{- range $kk, $vv := $v.plugins.hosts.entries }}
+        {{ $vv.ip }} {{ $vv.name }}
+      {{- end }}
+      {{- if $v.plugins.hosts.ttl }}
+        ttl {{ $v.plugins.hosts.ttl }}
+      {{- end }}
+      {{- if $v.plugins.hosts.no_reverse }}
+        no_reverse
+      {{- end }}
+      {{- if $v.plugins.hosts.reload }}
+        reload {{ $v.plugins.hosts.reload | quote }}
+      {{- end }}
+      {{- if $v.plugins.hosts.fallthrough }}
+        fallthrough
+      {{- end }}
+      }
+      {{- end }}
       {{- if $v.plugins.log }}
       log . {{ default "combined" $v.plugins.log.format }} {
         class {{ $v.plugins.log.classes }}

--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -60,6 +60,14 @@ config:
         prometheus: true
         health:
           port: 8080
+#        hosts:
+#          entries:     # dns.hosts INLINE
+#            - ip: 10.5.0.4
+#              name: blabla.lala
+#          ttl: 3600       # in seconds, 3600 (default)
+#          no_reverse: true    # set no_reverse
+#          reload: "0s"    # 0s disable (default), use duration notation, ie, "1.5h"
+#          fallthrough: true
     ip6.arpa:53:
       plugins:
         errors: true


### PR DESCRIPTION
Hi @MonolithProjects,

I've found that the [node-local-dns](registry.k8s.io/dns/k8s-dns-node-cache:1.22.9) image `v1.22.9` include the [dns.hosts](https://coredns.io/plugins/hosts/) CoreDNS plugin, so this PR is adding support for it.

Basically, adding this to the values.yaml, 
```yaml
config:
  localDnsIp: 169.254.20.11
  zones:
    .:53:
      plugins:
        [...]
        hosts:
          entries:     # dns.hosts INLINE
            - ip: 10.5.0.4
              name: blabla.lala
          ttl: 3600       # in seconds, 3600 (default)
          no_reverse: true    # set no_reverse
          reload: "0s"    # 0s disable (default), use duration notation, ie, "1.5h"
          fallthrough: true
        [...]
```

would produces a **Corefile** like this,

```yaml
  Corefile: |-
    .:53 {
      [...]
      hosts {
        10.5.0.4 blabla.lala
        ttl 3600
        no_reverse
        reload "0s"
        fallthrough
      }
    [...]
    }
```

I've left the example commented out just for reference.

Thank you!