### PR TITLE
add addressMatcher option

### DIFF
--- a/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
+++ b/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
@@ -12,9 +12,25 @@ metadata:
   {{- end }}
 spec:
   redirectFrontend:
+    {{- if eq .Values.config.cilium.redirectType "address" }}
+    addressMatcher:
+      ip: {{ .Values.config.localDnsIp }}
+      toPorts:
+      {{- if .Values.config.cilium.udp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+        protocol: UDP
+     {{- end }}
+     {{- if .Values.config.cilium.tcp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+        protocol: TCP
+     {{- end }}
+    {{- else }}
     serviceMatcher:
       serviceName: {{ .Values.config.cilium.clusterDNSService | default "kube-dns" }}
       namespace: {{ .Values.config.cilium.clusterDNSNamespace | default "kube-system" }}
+    {{- end }}
   redirectBackend:
     localEndpointSelector:
       matchLabels:

--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -20,6 +20,7 @@ config:
 #  cilium:
 #    clusterDNSService: kube-dns
 #    clusterDNSNamespace: kube-system
+#    redirectType: address
 #    udp:
 #      enabled: true
 #      portName: dns


### PR DESCRIPTION
# Description

We have our node local DNS set to a specific address in the `localDnsIp` while using Cilium. With `serviceMatcher`, the DNS request never makes it to the pods and our netshoot container just shows this error:

```
communications error to 169.254.20.10#53: timed out
```

With the new `addressMatcher` option, we can correctly route the 169.254.20.10 address to the backend pods where node-local-dns is running with Cilium enabled and acting as a kube-proxy replacement.
To use this matcher, you'll need to set something like this, specifically the `redirectType`:

```yaml
config:
  localDnsIp: 169.254.20.10
  cilium:
    clusterDNSService: kube-dns
    clusterDNSNamespace: kube-system
    redirectType: address
    udp:
      enabled: true
      portName: dns
    tcp:
      enabled: true
      portName: dns-tcp
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

Fired up a netshoot container and tried to resolve an FQDN

```
kubectl run --rm -it tmp-shell-host --image nicolaka/netshoot -- /bin/bash
dig google.com
```
