### PR TITLE
Missing ports in CiliumLocalRedirectPolicy ServiceMatcher

### DIFF
--- a/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
+++ b/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
@@ -20,16 +20,27 @@ spec:
       - port: "53"
         name: {{ .Values.config.cilium.udp.portName | default "dns" }}
         protocol: UDP
-     {{- end }}
-     {{- if .Values.config.cilium.tcp.enabled }}
+      {{- end }}
+      {{- if .Values.config.cilium.tcp.enabled }}
       - port: "53"
         name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
         protocol: TCP
-     {{- end }}
+      {{- end }}
     {{- else }}
     serviceMatcher:
       serviceName: {{ .Values.config.cilium.clusterDNSService | default "kube-dns" }}
       namespace: {{ .Values.config.cilium.clusterDNSNamespace | default "kube-system" }}
+      toPorts:
+      {{- if .Values.config.cilium.udp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+        protocol: UDP
+      {{- end }}
+      {{- if .Values.config.cilium.tcp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+        protocol: TCP
+      {{- end }}
     {{- end }}
   redirectBackend:
     localEndpointSelector:
@@ -40,10 +51,10 @@ spec:
       - port: "53"
         name: {{ .Values.config.cilium.udp.portName | default "dns" }}
         protocol: UDP
-     {{- end }}
-     {{- if .Values.config.cilium.tcp.enabled }}
+      {{- end }}
+      {{- if .Values.config.cilium.tcp.enabled }}
       - port: "53"
         name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
         protocol: TCP
-     {{- end }}
+      {{- end }}
 {{- end }}

--- a/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
+++ b/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
@@ -16,31 +16,31 @@ spec:
     addressMatcher:
       ip: {{ .Values.config.localDnsIp }}
       toPorts:
-      {{- if .Values.config.cilium.udp.enabled }}
-      - port: "53"
-        name: {{ .Values.config.cilium.udp.portName | default "dns" }}
-        protocol: UDP
-      {{- end }}
-      {{- if .Values.config.cilium.tcp.enabled }}
-      - port: "53"
-        name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
-        protocol: TCP
-      {{- end }}
+        {{- if .Values.config.cilium.udp.enabled }}
+        - port: "53"
+          name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+          protocol: UDP
+        {{- end }}
+        {{- if .Values.config.cilium.tcp.enabled }}
+        - port: "53"
+          name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+          protocol: TCP
+        {{- end }}
     {{- else }}
     serviceMatcher:
       serviceName: {{ .Values.config.cilium.clusterDNSService | default "kube-dns" }}
       namespace: {{ .Values.config.cilium.clusterDNSNamespace | default "kube-system" }}
       toPorts:
-      {{- if .Values.config.cilium.udp.enabled }}
-      - port: "53"
-        name: {{ .Values.config.cilium.udp.portName | default "dns" }}
-        protocol: UDP
-      {{- end }}
-      {{- if .Values.config.cilium.tcp.enabled }}
-      - port: "53"
-        name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
-        protocol: TCP
-      {{- end }}
+        {{- if .Values.config.cilium.udp.enabled }}
+        - port: "53"
+          name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+          protocol: UDP
+        {{- end }}
+        {{- if .Values.config.cilium.tcp.enabled }}
+        - port: "53"
+          name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+          protocol: TCP
+        {{- end }}
     {{- end }}
   redirectBackend:
     localEndpointSelector:


### PR DESCRIPTION
# Description

This MR adds the port mappings to `serviceMatcher` in `redirectFrontend` object. Without this port mappings, the DNS requests are not intercept by node-local-dns when Cilium's `kubeProxyReplacement` parameter is `true`. Adding this port mappings make it works.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
I tested it in a Kubernetes cluster, deployed with kubeadm and cluster-api. Without the ports, the metric `coredns_dns_requests_total` doesn't get increased. After adding the port mapping, when I execute `dig google.com` it get incremented.

The changes I made to the helm chart were testes locally using `helm template` utility

Metrics before changes in Cilium LRP:
```
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="."} 1
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="in-addr.arpa."} 1
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="ip6.arpa."} 1
``` 

Metrics after changes in Cilium LRP:
```
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="A",view="",zone="."} 5
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="."} 1
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="in-addr.arpa."} 1
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="ip6.arpa."} 1
```

Response time before changes in Cilium LRP:
```
root@my-app-6bb458975d-g7qt7:/# dig google.com                

; <<>> DiG 9.10.3-P4-Ubuntu <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 39772
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;google.com.			IN	A

;; ANSWER SECTION:
google.com.		30	IN	A	172.217.29.142

;; Query time: 7 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Fri May 23 15:22:55 UTC 2025
;; MSG SIZE  rcvd: 65
```

Response time after changes in Cilium LRP:
```
root@my-app-6bb458975d-g7qt7:/# dig google.com

; <<>> DiG 9.10.3-P4-Ubuntu <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 2381
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;google.com.			IN	A

;; ANSWER SECTION:
google.com.		28	IN	A	172.217.29.78

;; Query time: 0 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Fri May 23 15:31:53 UTC 2025
;; MSG SIZE  rcvd: 65
```