### PR TITLE
added the ability to provide custom upstream service selector

### DIFF
--- a/charts/node-local-dns/templates/service.yaml
+++ b/charts/node-local-dns/templates/service.yaml
@@ -27,5 +27,5 @@ spec:
     targetPort: 53
   {{- end }}
   selector:
-    k8s-app: kube-dns
+    {{- toYaml .Values.config.cilium.serviceSelector | nindent 4 }}
 {{- end }}

--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -29,6 +29,8 @@ config:
 #    tcp:
 #      enabled: true
 #      portName: dns-tcp
+#    serviceSelector:
+#      k8s-app: kube-dns
   zones:
     .:53:
       plugins:


### PR DESCRIPTION
# Description

This PR introduces a way to specify service selector for the upstream service that is created when using Cilium.
In my managed k8s cluster, the selector key is `k8s-app` but the value is `coredns` instead of the expected `kube-dns` and I need a way to configure it without forking this Helm chart and managing it by myself.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Tested using `helm template` since this is a static change, just introducing a way to specify custom selector for the upstream service that is created as part of this chart.
I've left the old hard-coded selector as default in the values introduced.