### PR TITLE
Fix bug in forward health_check configuration

### DIFF
--- a/charts/node-local-dns/templates/configmap.yaml
+++ b/charts/node-local-dns/templates/configmap.yaml
@@ -109,7 +109,7 @@ data:
         expire {{ $v.plugins.forward.expire }}
       {{- end }}
       {{- if $v.plugins.forward.health_check }}
-        expire {{ $v.plugins.forward.health_check }}
+        health_check {{ $v.plugins.forward.health_check }}
       {{- end }}
       {{- if $v.plugins.forward.except }}
         except {{ $v.plugins.forward.except }}


### PR DESCRIPTION
# Description
- Fix copy/paste bug in the `forward` configuration, where `expire` and `health_check` gets the same configuration.

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
