### PR TITLE
fix: serve_stale was never rendered, health_check was rendered as expire

### DIFF
--- a/charts/node-local-dns/Chart.yaml
+++ b/charts/node-local-dns/Chart.yaml
@@ -20,6 +20,7 @@ engine: gotpl
 type: application
 annotations:
   artifacthub.io/changes: |
+    - Support the VERIFY_TIMEOUT argument of cache.serve_stale
     - Fix cache.serve_stale never being read, the template tested cache.server_stale
     - Support duration and refresh_mode for cache.serve_stale
     - Fix forward.health_check being rendered as expire, which disabled upstream health checking

--- a/charts/node-local-dns/Chart.yaml
+++ b/charts/node-local-dns/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: node-local-dns
-version: 2.4.0
+version: 2.5.0
 appVersion: 1.23.1
 home: https://github.com/lablabs/k8s-nodelocaldns-helm
 description: NodeLocal DNS Cache helm chart
@@ -20,5 +20,6 @@ engine: gotpl
 type: application
 annotations:
   artifacthub.io/changes: |
-    - Initial helm chart changelog
-    - Update node-cache version, add support for better granular logging
+    - Fix cache.serve_stale never being read, the template tested cache.server_stale
+    - Support duration and refresh_mode for cache.serve_stale
+    - Fix forward.health_check being rendered as expire, which disabled upstream health checking

--- a/charts/node-local-dns/README.md
+++ b/charts/node-local-dns/README.md
@@ -2,7 +2,7 @@
 
 NodeLocal DNS Cache helm chart
 
-![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
+![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
 
 [<img src="https://lablabs.io/static/ll-logo.png" width=350px>](https://lablabs.io/)
 

--- a/charts/node-local-dns/templates/configmap.yaml
+++ b/charts/node-local-dns/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
         {{- end }}
         {{- if $v.plugins.cache.serve_stale }}
         {{- $serveStale := ternary $v.plugins.cache.serve_stale dict (kindIs "map" $v.plugins.cache.serve_stale) }}
-        serve_stale {{ $serveStale.duration | default "1h" }} {{ $serveStale.refresh_mode | default "immediate" }}
+        serve_stale {{ $serveStale.duration | default "1h" }} {{ $serveStale.refresh_mode | default "immediate" }}{{ with $serveStale.verify_timeout }} {{ . }}{{ end }}
         {{- end }}
       }
       {{- if $v.plugins.template }}

--- a/charts/node-local-dns/templates/configmap.yaml
+++ b/charts/node-local-dns/templates/configmap.yaml
@@ -27,8 +27,9 @@ data:
         {{- if $v.plugins.cache.prefetch }}
         prefetch {{ $v.plugins.cache.prefetch.amount }} {{ if $v.plugins.cache.prefetch.duration }} {{ $v.plugins.cache.prefetch.duration }} {{ end }} {{ if $v.plugins.cache.prefetch.percentage }} {{ $v.plugins.cache.prefetch.percentage }} {{ end }}
         {{- end }}
-        {{- if $v.plugins.cache.server_stale }}
-        serve_stale
+        {{- if $v.plugins.cache.serve_stale }}
+        {{- $serveStale := ternary $v.plugins.cache.serve_stale dict (kindIs "map" $v.plugins.cache.serve_stale) }}
+        serve_stale {{ $serveStale.duration | default "1h" }} {{ $serveStale.refresh_mode | default "immediate" }}
         {{- end }}
       }
       {{- if $v.plugins.template }}
@@ -109,7 +110,7 @@ data:
         expire {{ $v.plugins.forward.expire }}
       {{- end }}
       {{- if $v.plugins.forward.health_check }}
-        expire {{ $v.plugins.forward.health_check }}
+        health_check {{ $v.plugins.forward.health_check }}
       {{- end }}
       {{- if $v.plugins.forward.except }}
         except {{ $v.plugins.forward.except }}

--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -58,6 +58,12 @@ config:
             # amount: 1
             # duration: 10m
             # percentage: 20%
+          # Serve an expired answer when no upstream can be reached, instead of
+          # failing the query. Set to true for CoreDNS' defaults, or to a map to
+          # tune them. Note that an empty map is falsy in Helm and disables it.
+          #   serve_stale:
+          #     duration: 10m            # how long a stale answer stays usable, CoreDNS defaults to 1h
+          #     refresh_mode: immediate  # immediate|verify, CoreDNS defaults to immediate
           serve_stale: false
         forward:
           parameters: __PILLAR__UPSTREAM__SERVERS__   # defaults to /etc/resolv.conf

--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -64,6 +64,9 @@ config:
           #   serve_stale:
           #     duration: 10m            # how long a stale answer stays usable, CoreDNS defaults to 1h
           #     refresh_mode: immediate  # immediate|verify, CoreDNS defaults to immediate
+          #                              #   immediate: reply from the expired entry, refresh after
+          #                              #   verify: ask upstream first, fall back to the expired entry
+          #     verify_timeout: 1s       # how long verify waits before giving up, verify mode only
           serve_stale: false
         forward:
           parameters: __PILLAR__UPSTREAM__SERVERS__   # defaults to /etc/resolv.conf


### PR DESCRIPTION
Two directives in the Corefile template do not match what values.yaml documents.

cache.serve_stale is documented in values.yaml but the template tests cache.server_stale, so setting the documented key has no effect. Once corrected, the directive was still emitted bare, so its duration and refresh mode could not be configured and CoreDNS applied its 1h immediate defaults. cache.serve_stale now accepts true for those defaults, or a map with an optional duration and refresh_mode.

forward.health_check is rendered as expire, a different directive: upstream health checking is silently disabled while values.yaml suggests it is on, and an unrequested connection expiry is applied instead.

Note for users: anyone relying on the undocumented cache.server_stale key must move to cache.serve_stale. Beware that an empty map is falsy in Helm, so serve_stale: {} disables it; use true to enable with CoreDNS' defaults.

# Description

<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
